### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,5 +1,9 @@
 name: Detect Secrets
 
+# Restrict permissions to least privilege
+permissions:
+  contents: read
+
 # Run on all branches, not just main/master
 on:
   push:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,5 +1,8 @@
 name: Mypy Type Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,8 @@
 name: Pylint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -26,4 +29,3 @@ jobs:
     - name: Analysing the code with pylint
       run: |
         pylint --fail-under=7 $(git ls-files '*.py')
-


### PR DESCRIPTION
Potential fix for [https://github.com/ahmadasjad/duplicate-finder/security/code-scanning/1](https://github.com/ahmadasjad/duplicate-finder/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only reads repository contents (e.g., checking out code and analyzing Python files), the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
